### PR TITLE
Log, config, kafka improvements

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 [common]
   log_level = "info"
-  log_format = "json"
+  log_format = "logfmt"
   http_port = ":9601"
     [common.log_fields]
       runner = "local"

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 [common]
   log_level = "info"
-  log_format = "logfmt"
+  log_format = "json"
   http_port = ":9601"
     [common.log_fields]
       runner = "local"

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@
     [common.log_fields]
       runner = "local"
       dc = "east-01"
+      host = "${COMPUTERNAME}"
 
 [engine]
   storage = "fs"

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,7 @@ func ReadConfig(file string) (*Config, error) {
 		return nil, err
 	}
 
+	buf = []byte(os.ExpandEnv(string(buf)))
 	config := Default
 
 	switch e := filepath.Ext(file); e {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,6 +12,8 @@ The daemon part configures Neptunus app and pipelines engine.
  - **http_port**: Address for HTTP api server. See more in [api documentation](API.md).
  - **log_fields**: A map of fields, that will be added to each log entry.
 
+You can also use environment variables in daemon config with `${MY_VAR}` syntax. Please note than replacement occurs before file parsing.
+
 Here is a common part example:
 ```toml
 [common]
@@ -21,6 +23,7 @@ Here is a common part example:
   [common.log_fields]
     stage = "dev"
     dc = "east-01"
+    host = "${HOSTNAME}"
 ```
 
 **Engine** section used for pipelines engine settings:

--- a/logger/slog.go
+++ b/logger/slog.go
@@ -35,8 +35,10 @@ func Init(cfg config.Common) error {
 
 	switch f := cfg.LogFormat; f {
 	case "logfmt":
+		opts.ReplaceAttr = attrReplacer
 		handler = slog.NewTextHandler(os.Stdout, opts)
 	case "json":
+		opts.ReplaceAttr = attrReplacer
 		handler = slog.NewJSONHandler(os.Stdout, opts)
 	case "pretty":
 		handler = prettylog.NewHandler(opts)
@@ -58,4 +60,16 @@ func Init(cfg config.Common) error {
 
 func Mock() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func attrReplacer(_ []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey {
+		a.Key = "@timestamp"
+	}
+
+	if a.Key == slog.MessageKey {
+		a.Key = "message"
+	}
+
+	return a
 }


### PR DESCRIPTION
 - daemon log now supports ENVs expand
 - `json` and `logfmt` loggers - fields `time` and `msg` replaced with `@timestamp` and `message`
 - `kafka` plugins - added connections init check to prevent pipeline startup if brokers unavailable via network