### PR TITLE
Windows, Linux, Darwin amd64 and arm64 builds

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -28,11 +28,17 @@ jobs:
         run: |
           task -v \
             build:linux-amd64 \
+            build:linux-arm64 \
             build:windows-amd64 \
+            build:windows-arm64 \
+            build:darwin-amd64 \
             build:darwin-arm64 \
             build:notice \
             pack:linux-amd64 \
+            pack:linux-arm64 \
             pack:windows-amd64 \
+            pack:windows-arm64 \
+            pack:darwin-amd64 \
             pack:darwin-arm64
 
       - name: Upload artifacts

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ neptunus pipeline --help
 ```
 
 # How to build
-This project uses [Taskfile](https://taskfile.dev/) as a build tool. Out-of-the-box there is three os-platform combinations: `windows/amd64`, `linux/amd64` and `darwin/arm64`. You can add more in [builds](./Taskfile.build.yaml) and [packs](./Taskfile.pack.yaml) tasks if you need. All tasks should be cross-platform, but you need to know that it tested on Windows and Linux (Ubuntu 22.04) only.
+This project uses [Taskfile](https://taskfile.dev/) as a build tool. Out-of-the-box there is three OS and two platform combinations: `linux`, `windows`, `darwin` and `amd64`, `arm64`. You can add more in [builds](./Taskfile.build.yaml) and [packs](./Taskfile.pack.yaml) tasks if you need. All tasks should be cross-platform, but you need to know that it tested on Windows 10 and Linux (Ubuntu 22.04) only.
 
 Then, follow simple steps:
 1. Install [Taskfile](https://github.com/go-task/task) and [go-licence-detector](https://github.com/elastic/go-licence-detector)
-2. Run `task build:{{ OS }}-{{ PLATFORM }}`
-3. Run `task build:notice`
-4. Run `task pack:{{ OS }}-{{ PLATFORM }}` (this is optional, btw)
-5. Run `task build:docker` if you need docker image
+2. Run `task build:{{ OS }}-{{ PLATFORM }}` to build binary
+3. Run `task build:notice` to generate NOTICE.txt file
+4. Run `task pack:{{ OS }}-{{ PLATFORM }}` to pack your build
+5. Run `task build:docker` or `task build:podman` if you need container image
 6. Finally, run `task cleanup` to remove build artifacts from file system

--- a/Taskfile.build.yaml
+++ b/Taskfile.build.yaml
@@ -17,12 +17,36 @@ tasks:
         NEPTUNUS_BUILD_GOOS: linux
         NEPTUNUS_BUILD_GOARCH: amd64
 
+  linux-arm64:
+    desc: Build linux/arm64 binary
+    cmds:
+    - task: generics:build
+      vars:
+        NEPTUNUS_BUILD_GOOS: linux
+        NEPTUNUS_BUILD_GOARCH: arm64
+
   windows-amd64:
     desc: Build windows/amd64 binary
     cmds:
     - task: generics:build
       vars:
         NEPTUNUS_BUILD_GOOS: windows
+        NEPTUNUS_BUILD_GOARCH: amd64
+
+  windows-arm64:
+    desc: Build windows/arm64 binary
+    cmds:
+    - task: generics:build
+      vars:
+        NEPTUNUS_BUILD_GOOS: windows
+        NEPTUNUS_BUILD_GOARCH: arm64
+
+  darwin-amd64:
+    desc: Build darwin/amd64 binary
+    cmds:
+    - task: generics:build
+      vars:
+        NEPTUNUS_BUILD_GOOS: darwin
         NEPTUNUS_BUILD_GOARCH: amd64
 
   darwin-arm64:
@@ -34,9 +58,18 @@ tasks:
         NEPTUNUS_BUILD_GOARCH: arm64
 
   docker:
-    desc: Build docker image
+    desc: Build container image using docker
     cmds:
-    - task: generics:docker
+    - task: generics:container
+      vars:
+        NEPTUNUS_CONTAINER_TOOL: docker
+
+  podman:
+    desc: Build container image using podman
+    cmds:
+    - task: generics:container
+      vars:
+        NEPTUNUS_CONTAINER_TOOL: podman
 
   tests:
     desc: Run tests

--- a/Taskfile.generics.yaml
+++ b/Taskfile.generics.yaml
@@ -6,12 +6,13 @@ tasks:
     requires:
       vars: [ NEPTUNUS_BUILD_DIR, NEPTUNUS_BUILD_GOOS, NEPTUNUS_BUILD_GOARCH, NEPTUNUS_BUILD_VERSION ]
     cmds:
-    - platforms: [ linux/amd64, darwin/arm64 ]
+    - platforms: [ linux, darwin ]
       cmd: |
         mkdir -p {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}
-    - platforms: [ windows/amd64 ]
+    - platforms: [ windows ]
       cmd: |
-        powershell New-Item -ItemType Directory -Force -Path {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}
+        powershell New-Item -ItemType Directory -Force \
+        -Path {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}
     - cmd: |
         export GOOS="{{ .NEPTUNUS_BUILD_GOOS }}"
         export GOARCH="{{ .NEPTUNUS_BUILD_GOARCH }}"
@@ -19,6 +20,8 @@ tasks:
           -ldflags="-X main.Version={{ .NEPTUNUS_BUILD_VERSION }}" \
           -o {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }} \
           ./cmd/neptunus
+    status:
+    - test -f {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}/neptunus{{ exeExt }}
 
   tar:
     internal: true
@@ -33,6 +36,8 @@ tasks:
         -czvf {{ .NEPTUNUS_BUILD_DIR }}/neptunus-{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}.tar.gz \
         -C {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }} neptunus \
         -C ../../{{ .NEPTUNUS_BUILD_DIR }} NOTICE.txt
+    status:
+    - test -f {{ .NEPTUNUS_BUILD_DIR }}/neptunus-{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}.tar.gz
 
   zip:
     internal: true
@@ -42,30 +47,33 @@ tasks:
     - test -f {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}/neptunus.exe
     - test -f {{ .NEPTUNUS_BUILD_DIR }}/NOTICE.txt
     cmds:
-    - platforms: [ linux/amd64, darwin/arm64 ]
+    - platforms: [ linux, darwin ]
       cmd: |
         zip \
         -rj \
         {{ .NEPTUNUS_BUILD_DIR }}/neptunus-{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}.zip \
         {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}/neptunus.exe \
         {{ .NEPTUNUS_BUILD_DIR }}/NOTICE.txt
-    - platforms: [ windows/amd64 ]
+    - platforms: [ windows ]
       cmd: |
         powershell Compress-Archive \
-        -DestinationPath {{ .NEPTUNUS_BUILD_DIR }}/neptunus-{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}.zip \
+        -DestinationPath \ {{ .NEPTUNUS_BUILD_DIR }}/neptunus-{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}.zip \
         -Path \
         {{ .NEPTUNUS_BUILD_DIR }}/{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}/neptunus.exe, \
         {{ .NEPTUNUS_BUILD_DIR }}/NOTICE.txt
+    status:
+    - test -f {{ .NEPTUNUS_BUILD_DIR }}/neptunus-{{ .NEPTUNUS_BUILD_GOOS }}-{{ .NEPTUNUS_BUILD_GOARCH }}-{{ .NEPTUNUS_BUILD_VERSION }}.zip
+
 
   notice:
     internal: true
     requires:
       vars: [ NEPTUNUS_BUILD_DIR ]
     cmds:
-    - platforms: [ linux/amd64, darwin/arm64 ]
+    - platforms: [ linux, darwin ]
       cmd: |
         mkdir -p {{ .NEPTUNUS_BUILD_DIR }}
-    - platforms: [ windows/amd64 ]
+    - platforms: [ windows ]
       cmd: |
         powershell New-Item -ItemType Directory -Force -Path {{ .NEPTUNUS_BUILD_DIR }}
     - cmd: |
@@ -76,18 +84,19 @@ tasks:
           -noticeTemplate '.github/NOTICE.txt.tmpl' \
           -noticeOut '{{ .NEPTUNUS_BUILD_DIR }}/NOTICE.txt'   
 
-  docker:
+  container:
     internal: true
     requires:
-      vars: [ NEPTUNUS_BUILD_VERSION ]
+      vars: [ NEPTUNUS_BUILD_VERSION, NEPTUNUS_CONTAINER_TOOL ]
     cmds:
     - |
-      docker build \
+      {{ .NEPTUNUS_CONTAINER_TOOL }} build \
         --build-arg NEPTUNUS_VERSION={{ .NEPTUNUS_BUILD_VERSION }} \
         -t ghcr.io/gekatateam/neptunus:{{ trimPrefix "v" .NEPTUNUS_BUILD_VERSION }} \
         .
     status:
-    - docker inspect --type=image ghcr.io/gekatateam/neptunus:{{ trimPrefix "v" .NEPTUNUS_BUILD_VERSION }}
+    - |
+      {{ .NEPTUNUS_CONTAINER_TOOL }} inspect --type=image ghcr.io/gekatateam/neptunus:{{ trimPrefix "v" .NEPTUNUS_BUILD_VERSION }}
 
   cleanup:
     internal: true
@@ -95,9 +104,9 @@ tasks:
       vars: [ NEPTUNUS_BUILD_DIR ]
     prompt: '{{ .NEPTUNUS_BUILD_DIR }}/ directory will be deleted. Do you want to continue?'
     cmds:
-    - platforms: [ linux/amd64, darwin/arm64 ]
+    - platforms: [ linux, darwin ]
       cmd: |
         rm -rf {{ .NEPTUNUS_BUILD_DIR }}
-    - platforms: [ windows/amd64 ]
+    - platforms: [ windows ]
       cmd: |
-        powershell Remove-Item -LiteralPath {{ .NEPTUNUS_BUILD_DIR }} -Force -Recurse
+        powershell Remove-Item -LiteralPath {{ .NEPTUNUS_BUILD_DIR }} -Force -Recurse | $null

--- a/Taskfile.pack.yaml
+++ b/Taskfile.pack.yaml
@@ -12,12 +12,36 @@ tasks:
         NEPTUNUS_BUILD_GOOS: linux
         NEPTUNUS_BUILD_GOARCH: amd64
 
+  linux-arm64:
+    desc: Create linux/arm64 tar.gz
+    cmds:
+    - task: generics:tar
+      vars:
+        NEPTUNUS_BUILD_GOOS: linux
+        NEPTUNUS_BUILD_GOARCH: arm64
+
   windows-amd64:
     desc: Create windows/amd64 zip
     cmds:
     - task: generics:zip
       vars:
         NEPTUNUS_BUILD_GOOS: windows
+        NEPTUNUS_BUILD_GOARCH: amd64
+
+  windows-arm64:
+    desc: Create windows/arm64 zip
+    cmds:
+    - task: generics:zip
+      vars:
+        NEPTUNUS_BUILD_GOOS: windows
+        NEPTUNUS_BUILD_GOARCH: arm64
+
+  darwin-amd64:
+    desc: Create darwin/amd64 tar.gz
+    cmds:
+    - task: generics:tar
+      vars:
+        NEPTUNUS_BUILD_GOOS: darwin
         NEPTUNUS_BUILD_GOARCH: amd64
 
   darwin-arm64:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -22,14 +22,19 @@ tasks:
     - task: generics:cleanup
 
   all:
-    desc: Build and pack all artifacts
+    desc: Build and pack all binaries
     cmds:
     - task: build:tests
     - task: build:linux-amd64
+    - task: build:linux-arm64
     - task: build:windows-amd64
+    - task: build:windows-arm64
+    - task: build:darwin-amd64
     - task: build:darwin-arm64
     - task: build:notice
-    - task: build:docker
     - task: pack:linux-amd64
+    - task: pack:linux-arm64
     - task: pack:windows-amd64
+    - task: pack:windows-arm64
+    - task: pack:darwin-amd64
     - task: pack:darwin-arm64


### PR DESCRIPTION
Also:
 - `build:podman` task to build container image using podman
 - generic `build`, `zip` and `pack` tasks now checks if result exists before run