### PR TITLE
dynamic template processor

### DIFF
--- a/.pipelines/test.pipeline.dtemplate.toml
+++ b/.pipelines/test.pipeline.dtemplate.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.dtemplate"
   lines = 2
-  run = false
+  run = true
   buffer = 5
 
 [[inputs]]

--- a/.pipelines/test.pipeline.dtemplate.toml
+++ b/.pipelines/test.pipeline.dtemplate.toml
@@ -1,0 +1,30 @@
+[settings]
+  id = "test.pipeline.dtemplate"
+  lines = 2
+  run = true
+  buffer = 5
+
+[[inputs]]
+  [inputs.http]
+    address = ":9100"
+    max_connections = 10
+    query_params_to = ""
+    wait_for_delivery = false
+    tls_enable = false
+    [inputs.http.parser]
+      type = "json"
+      split_array = true
+
+[[processors]]
+ [processors.defaults.labels]
+   tmplabel = '{{ .RoutingKey }}-{{ .Timestamp.Format "2006-01-02" }}'
+
+[[processors]]
+  [processors.dynamic_template]
+      labels = [ "tmplabel" ]
+      fields = [ "annotations", "legend", "reason", "number" ]
+
+[[outputs]]
+  [outputs.log]
+    [outputs.log.serializer]
+      type = "json"

--- a/.pipelines/test.pipeline.dtemplate.toml
+++ b/.pipelines/test.pipeline.dtemplate.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.dtemplate"
   lines = 2
-  run = true
+  run = false
   buffer = 5
 
 [[inputs]]

--- a/.pipelines/test.pipeline.httpout.toml
+++ b/.pipelines/test.pipeline.httpout.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.httpout"
   lines = 1
-  run = true
+  run = false
   buffer = 1_000
   log_level = "debug"
 

--- a/.pipelines/test.pipeline.sqlproc.toml
+++ b/.pipelines/test.pipeline.sqlproc.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.sqlproc"
   lines = 2
-  run = true
+  run = false
   buffer = 5
 
 [[inputs]]

--- a/.pipelines/test.pipeline.sqlproc.toml
+++ b/.pipelines/test.pipeline.sqlproc.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.sqlproc"
   lines = 2
-  run = false
+  run = true
   buffer = 5
 
 [[inputs]]

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -363,10 +363,7 @@ func (p *Pipeline) Run(ctx context.Context) {
 	}
 	wg.Wait()
 
-	for _, k := range p.keepers {
-		k.Close()
-	}
-
+	p.Close()
 	p.log.Info("pipeline stopped")
 	p.state = StateStopped
 }

--- a/plugins/common/sharedstorage/sharedstorage.go
+++ b/plugins/common/sharedstorage/sharedstorage.go
@@ -1,0 +1,54 @@
+package sharedstorage
+
+import (
+	"io"
+	"sync"
+)
+
+type SharedStorage[T any] struct {
+	mu      *sync.Mutex
+	objects map[uint64]T
+	members map[uint64]int
+}
+
+func New[T any]() *SharedStorage[T] {
+	return &SharedStorage[T]{
+		mu:      &sync.Mutex{},
+		objects: make(map[uint64]T),
+		members: make(map[uint64]int),
+	}
+}
+
+func (s *SharedStorage[T]) CompareAndStore(id uint64, obj T) T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.members[id]; !ok {
+		s.members[id] = 0
+	}
+	s.members[id]++
+
+	if c, ok := s.objects[id]; ok {
+		if closer, ok := any(obj).(io.Closer); ok {
+			closer.Close()
+		}
+		return c
+	}
+
+	s.objects[id] = obj
+	return obj
+}
+
+func (s *SharedStorage[T]) Leave(id uint64) (last bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.members[id]--
+	if s.members[id] == 0 {
+		delete(s.objects, id)
+		delete(s.members, id)
+		return true
+	}
+
+	return false
+}

--- a/plugins/processors/all.go
+++ b/plugins/processors/all.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/gekatateam/neptunus/plugins/processors/defaults"
 	_ "github.com/gekatateam/neptunus/plugins/processors/delete"
 	_ "github.com/gekatateam/neptunus/plugins/processors/drop"
+	_ "github.com/gekatateam/neptunus/plugins/processors/dynamic_template"
 	_ "github.com/gekatateam/neptunus/plugins/processors/http"
 	_ "github.com/gekatateam/neptunus/plugins/processors/line"
 	_ "github.com/gekatateam/neptunus/plugins/processors/log"

--- a/plugins/processors/deduplicate/README.md
+++ b/plugins/processors/deduplicate/README.md
@@ -19,10 +19,6 @@ Processor adds `::duplicate` label to event with with `true` value if duplicate 
 
     # Redis connection config
     [processors.deduplicate.redis]
-      # if true, one Redis client is shared between processors in set
-      # otherwise, each plugin uses a personal client
-      shared = true
-
       # list of Redis nodes
       servers = [ "localhost:6379" ]
 

--- a/plugins/processors/deduplicate/client.go
+++ b/plugins/processors/deduplicate/client.go
@@ -1,51 +1,9 @@
 package deduplicate
 
 import (
-	"sync"
-
 	"github.com/redis/go-redis/v9"
+
+	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
 )
 
-var clientStorage = &redisClientStorage{
-	mu:      &sync.Mutex{},
-	clients: make(map[uint64]redis.UniversalClient),
-	members: make(map[uint64]int),
-}
-
-type redisClientStorage struct {
-	mu      *sync.Mutex
-	clients map[uint64]redis.UniversalClient
-	members map[uint64]int
-}
-
-func (s *redisClientStorage) CompareAndStore(id uint64, client redis.UniversalClient) redis.UniversalClient {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.members[id]; !ok {
-		s.members[id] = 0
-	}
-	s.members[id]++
-
-	if c, ok := s.clients[id]; ok {
-		client.Close()
-		return c
-	}
-
-	s.clients[id] = client
-	return client
-}
-
-func (s *redisClientStorage) Leave(id uint64) (last bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.members[id]--
-	if s.members[id] == 0 {
-		delete(s.clients, id)
-		delete(s.members, id)
-		return true
-	}
-
-	return false
-}
+var clientStorage = sharedstorage.New[redis.UniversalClient]()

--- a/plugins/processors/deduplicate/client.go
+++ b/plugins/processors/deduplicate/client.go
@@ -9,16 +9,23 @@ import (
 var clientStorage = &redisClientStorage{
 	mu:      &sync.Mutex{},
 	clients: make(map[uint64]redis.UniversalClient),
+	members: make(map[uint64]int),
 }
 
 type redisClientStorage struct {
 	mu      *sync.Mutex
 	clients map[uint64]redis.UniversalClient
+	members map[uint64]int
 }
 
 func (s *redisClientStorage) CompareAndStore(id uint64, client redis.UniversalClient) redis.UniversalClient {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if _, ok := s.members[id]; !ok {
+		s.members[id] = 0
+	}
+	s.members[id]++
 
 	if c, ok := s.clients[id]; ok {
 		client.Close()
@@ -27,4 +34,18 @@ func (s *redisClientStorage) CompareAndStore(id uint64, client redis.UniversalCl
 
 	s.clients[id] = client
 	return client
+}
+
+func (s *redisClientStorage) Leave(id uint64) (last bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.members[id]--
+	if s.members[id] == 0 {
+		delete(s.clients, id)
+		delete(s.members, id)
+		return true
+	}
+
+	return false
 }

--- a/plugins/processors/dynamic_template/README.md
+++ b/plugins/processors/dynamic_template/README.md
@@ -2,7 +2,7 @@
 
 The `dynamic_template` processor evaluates [Golang templates](https://pkg.go.dev/text/template) in configured labels and fields. [Slim-sprig functions](https://go-task.github.io/slim-sprig/) available!
 
-Unlike [template processor](../template/), this plugin does not use predefined templates.
+Unlike [template processor](../template/), this plugin does not use predefined templates. Instead, it uses **label or field content** as a template and replaces it by execution result.
 
 Plugin uses [wrapped events](../../common/template/README.md).
 

--- a/plugins/processors/dynamic_template/README.md
+++ b/plugins/processors/dynamic_template/README.md
@@ -1,0 +1,24 @@
+# Dynamic Template Processor Plugin
+
+The `dynamic_template` processor evaluates [Golang templates](https://pkg.go.dev/text/template) in configured labels and fields. [Slim-sprig functions](https://go-task.github.io/slim-sprig/) available!
+
+Unlike [template processor](../template/), this plugin does not use predefined templates.
+
+Plugin uses [wrapped events](../../common/template/README.md).
+
+If template execution fails, event is marked as failed, but other templates execution continues.
+
+## Configuration
+```toml
+[[processors]]
+  [processors.dynamic_template]
+    # compiled template TTL
+    template_ttl = "1h"
+
+    # list of labels to evaluate
+    labels = [ "hello_message" ]
+
+    # list of fields to evaluate
+    # field must be a string or a slice/map of strings
+    fields = [ "annotations" ]
+```

--- a/plugins/processors/dynamic_template/cache.go
+++ b/plugins/processors/dynamic_template/cache.go
@@ -1,0 +1,71 @@
+package dynamic_template
+
+import (
+	"sync"
+	"text/template"
+	"time"
+)
+
+var cache = templateCache{
+	u:  0,
+	m:  make(map[string]*template.Template),
+	d:  make(map[string]time.Time),
+	mu: &sync.RWMutex{},
+}
+
+type templateCache struct {
+	u  int
+	m  map[string]*template.Template
+	d  map[string]time.Time
+	mu *sync.RWMutex
+}
+
+func (c *templateCache) Reg() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.u++
+}
+
+func (c *templateCache) Get(key string) (*template.Template, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	t, ok := c.m[key]
+	if ok {
+		c.d[key] = time.Now()
+	}
+
+	return t, ok
+}
+
+func (c *templateCache) Put(key string, t *template.Template) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.m[key] = t
+	c.d[key] = time.Now()
+}
+
+func (c *templateCache) DropOlderThan(olderThan time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for k, v := range c.d {
+		if time.Since(v) > olderThan {
+			delete(c.d, k)
+			delete(c.m, k)
+		}
+	}
+}
+
+func (c *templateCache) Leave() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.u--
+	if c.u == 0 {
+		clear(c.m)
+		clear(c.d)
+	}
+}

--- a/plugins/processors/dynamic_template/dynamic_template.go
+++ b/plugins/processors/dynamic_template/dynamic_template.go
@@ -1,0 +1,183 @@
+package dynamic_template
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+	"time"
+
+	sprig "github.com/go-task/slim-sprig/v3"
+
+	"github.com/gekatateam/neptunus/core"
+	"github.com/gekatateam/neptunus/metrics"
+	"github.com/gekatateam/neptunus/plugins"
+	"github.com/gekatateam/neptunus/plugins/common/elog"
+	cte "github.com/gekatateam/neptunus/plugins/common/template"
+)
+
+type DynamicTemplate struct {
+	*core.BaseProcessor `mapstructure:"-"`
+	TemplateTTL         time.Duration `mapstructure:"template_ttl"`
+	Labels              []string      `mapstructure:"labels"`
+	Fields              []string      `mapstructure:"fields"`
+
+	buf *bytes.Buffer
+}
+
+func (p *DynamicTemplate) Init() error {
+	cache.Reg()
+	p.buf = bytes.NewBuffer(make([]byte, 0, 1024))
+	return nil
+}
+
+func (p *DynamicTemplate) Close() error {
+	cache.Leave()
+	return nil
+}
+
+func (p *DynamicTemplate) Run() {
+	clearTicker := time.NewTicker(time.Minute)
+	if p.TemplateTTL == 0 {
+		clearTicker.Stop()
+	}
+
+MAIN_LOOP:
+	for {
+		select {
+		case e, ok := <-p.In:
+			if !ok {
+				clearTicker.Stop()
+				break MAIN_LOOP
+			}
+
+			now := time.Now()
+			if p.process(e) {
+				p.Observe(metrics.EventAccepted, time.Since(now))
+			} else {
+				p.Observe(metrics.EventFailed, time.Since(now))
+			}
+			p.Out <- e
+		case <-clearTicker.C:
+			cache.DropOlderThan(p.TemplateTTL)
+		}
+	}
+}
+
+func (p *DynamicTemplate) process(e *core.Event) (allOk bool) {
+	hasError := false
+
+	for _, l := range p.Labels {
+		labelRaw, ok := e.GetLabel(l)
+		if !ok {
+			continue
+		}
+
+		result, ok := p.processTemplate(e, fmt.Sprintf("label:%v", l), labelRaw)
+		if !ok {
+			hasError = true
+			continue
+		}
+		e.SetLabel(l, result)
+	}
+
+	for _, f := range p.Fields {
+		fieldRaw, err := e.GetField(f)
+		if err != nil {
+			continue
+		}
+
+		switch field := fieldRaw.(type) {
+		case string:
+			result, ok := p.processTemplate(e, fmt.Sprintf("field:%v", f), field)
+			if !ok {
+				hasError = true
+				continue
+			}
+			e.SetField(f, result)
+		case map[string]any:
+			for k, v := range field {
+				data, ok := v.(string)
+				if !ok {
+					p.Log.Warn(fmt.Sprintf("%v.%v is not a string", f, k),
+						elog.EventGroup(e),
+					)
+					continue
+				}
+
+				result, ok := p.processTemplate(e, fmt.Sprintf("field:%v.%v", f, k), data)
+				if !ok {
+					hasError = true
+					continue
+				}
+				field[k] = result
+			}
+
+			e.SetField(f, field)
+		case []any:
+			for i, v := range field {
+				data, ok := v.(string)
+				if !ok {
+					p.Log.Warn(fmt.Sprintf("%v.%v is not a string", f, i),
+						elog.EventGroup(e),
+					)
+					continue
+				}
+
+				result, ok := p.processTemplate(e, fmt.Sprintf("field:%v.%v", f, i), data)
+				if !ok {
+					hasError = true
+					continue
+				}
+				field[i] = result
+			}
+
+			e.SetField(f, field)
+		default:
+			p.Log.Warn(fmt.Sprintf("%v is not a string, slice or map", f),
+				elog.EventGroup(e),
+			)
+			continue
+		}
+	}
+
+	return !hasError
+}
+
+func (p *DynamicTemplate) processTemplate(e *core.Event, source, content string) (result string, ok bool) {
+	t, ok := cache.Get(content)
+	if !ok { // if there is no template, try to create it and put in cache
+		var err error
+		t, err = template.New("template").Funcs(sprig.FuncMap()).Parse(content)
+		if err != nil {
+			p.Log.Error("template parsing failed",
+				"error", fmt.Errorf("%v: %w", source, err),
+				elog.EventGroup(e),
+			)
+			e.StackError(fmt.Errorf("%v: %w", source, err))
+			return "", false
+		}
+
+		cache.Put(content, t)
+	}
+
+	te := cte.New(e)
+	if err := t.Execute(p.buf, te); err != nil {
+		p.Log.Error("template exec failed",
+			"error", fmt.Errorf("%v: %w", source, err),
+			elog.EventGroup(e),
+		)
+		e.StackError(fmt.Errorf("%v: %w", source, err))
+		return "", false
+	}
+
+	defer p.buf.Reset()
+	return p.buf.String(), true
+}
+
+func init() {
+	plugins.AddProcessor("dynamic_template", func() core.Processor {
+		return &DynamicTemplate{
+			TemplateTTL: time.Hour,
+		}
+	})
+}

--- a/plugins/processors/http/client.go
+++ b/plugins/processors/http/client.go
@@ -2,48 +2,8 @@ package http
 
 import (
 	"net/http"
-	"sync"
+
+	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
 )
 
-var clientStorage = &httpClientStorage{
-	mu:      &sync.Mutex{},
-	clients: make(map[uint64]*http.Client),
-	members: make(map[uint64]int),
-}
-
-type httpClientStorage struct {
-	mu      *sync.Mutex
-	clients map[uint64]*http.Client
-	members map[uint64]int
-}
-
-func (s *httpClientStorage) CompareAndStore(id uint64, client *http.Client) *http.Client {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.members[id]; !ok {
-		s.members[id] = 0
-	}
-	s.members[id]++
-
-	if c, ok := s.clients[id]; ok {
-		return c
-	}
-
-	s.clients[id] = client
-	return client
-}
-
-func (s *httpClientStorage) Leave(id uint64) (last bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.members[id]--
-	if s.members[id] == 0 {
-		delete(s.clients, id)
-		delete(s.members, id)
-		return true
-	}
-
-	return false
-}
+var clientStorage = sharedstorage.New[*http.Client]()

--- a/plugins/processors/http/client.go
+++ b/plugins/processors/http/client.go
@@ -8,16 +8,23 @@ import (
 var clientStorage = &httpClientStorage{
 	mu:      &sync.Mutex{},
 	clients: make(map[uint64]*http.Client),
+	members: make(map[uint64]int),
 }
 
 type httpClientStorage struct {
 	mu      *sync.Mutex
 	clients map[uint64]*http.Client
+	members map[uint64]int
 }
 
 func (s *httpClientStorage) CompareAndStore(id uint64, client *http.Client) *http.Client {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if _, ok := s.members[id]; !ok {
+		s.members[id] = 0
+	}
+	s.members[id]++
 
 	if c, ok := s.clients[id]; ok {
 		return c
@@ -25,4 +32,18 @@ func (s *httpClientStorage) CompareAndStore(id uint64, client *http.Client) *htt
 
 	s.clients[id] = client
 	return client
+}
+
+func (s *httpClientStorage) Leave(id uint64) (last bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.members[id]--
+	if s.members[id] == 0 {
+		delete(s.clients, id)
+		delete(s.members, id)
+		return true
+	}
+
+	return false
 }

--- a/plugins/processors/http/http.go
+++ b/plugins/processors/http/http.go
@@ -92,7 +92,9 @@ func (p *Http) Init() error {
 func (p *Http) Close() error {
 	p.ser.Close()
 	p.parser.Close()
-	p.client.CloseIdleConnections()
+	if clientStorage.Leave(p.id) {
+		p.client.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/plugins/processors/sql/README.md
+++ b/plugins/processors/sql/README.md
@@ -30,10 +30,6 @@ Drivers use plugin TLS configuration.
     username = ""
     password = ""
 
-    # if true, one SQL client is shared between processors in set
-    # otherwise, each plugin uses a personal client
-    shared = true
-
     # database connection params - https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime
     conns_max_idle_time = "10m"
     conns_max_life_time = "10m"

--- a/plugins/processors/sql/client.go
+++ b/plugins/processors/sql/client.go
@@ -9,16 +9,23 @@ import (
 var clientStorage = &dbClientStorage{
 	mu:      &sync.Mutex{},
 	clients: make(map[uint64]*sqlx.DB),
+	members: make(map[uint64]int),
 }
 
 type dbClientStorage struct {
 	mu      *sync.Mutex
 	clients map[uint64]*sqlx.DB
+	members map[uint64]int
 }
 
 func (s *dbClientStorage) CompareAndStore(id uint64, client *sqlx.DB) *sqlx.DB {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if _, ok := s.members[id]; !ok {
+		s.members[id] = 0
+	}
+	s.members[id]++
 
 	if c, ok := s.clients[id]; ok {
 		client.Close()
@@ -27,4 +34,18 @@ func (s *dbClientStorage) CompareAndStore(id uint64, client *sqlx.DB) *sqlx.DB {
 
 	s.clients[id] = client
 	return client
+}
+
+func (s *dbClientStorage) Leave(id uint64) (last bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.members[id]--
+	if s.members[id] == 0 {
+		delete(s.clients, id)
+		delete(s.members, id)
+		return true
+	}
+
+	return false
 }

--- a/plugins/processors/sql/client.go
+++ b/plugins/processors/sql/client.go
@@ -1,51 +1,9 @@
 package sql
 
 import (
-	"sync"
-
 	"github.com/jmoiron/sqlx"
+
+	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
 )
 
-var clientStorage = &dbClientStorage{
-	mu:      &sync.Mutex{},
-	clients: make(map[uint64]*sqlx.DB),
-	members: make(map[uint64]int),
-}
-
-type dbClientStorage struct {
-	mu      *sync.Mutex
-	clients map[uint64]*sqlx.DB
-	members map[uint64]int
-}
-
-func (s *dbClientStorage) CompareAndStore(id uint64, client *sqlx.DB) *sqlx.DB {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.members[id]; !ok {
-		s.members[id] = 0
-	}
-	s.members[id]++
-
-	if c, ok := s.clients[id]; ok {
-		client.Close()
-		return c
-	}
-
-	s.clients[id] = client
-	return client
-}
-
-func (s *dbClientStorage) Leave(id uint64) (last bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.members[id]--
-	if s.members[id] == 0 {
-		delete(s.clients, id)
-		delete(s.members, id)
-		return true
-	}
-
-	return false
-}
+var clientStorage = sharedstorage.New[*sqlx.DB]()


### PR DESCRIPTION
Also:
 - `shared` param removed from `sql` and `deduplicate` processors; it is always `true` from this moment
 - `sql`, `http` and `deduplicate` processors closing fixed - now they releasing sql/http/redis clients only when all processors in set closed
 - new common plugin - `SharedStorage` - for common cases when plugins needs to use shared resources