### PR TITLE
http processor fallbacks support

### DIFF
--- a/.pipelines/test.pipeline.execproc.toml
+++ b/.pipelines/test.pipeline.execproc.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.execproc"
   lines = 3
-  run = true
+  run = false
   buffer = 1_000
 
 [[inputs]]

--- a/.pipelines/test.pipeline.httpproc.toml
+++ b/.pipelines/test.pipeline.httpproc.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.httpproc"
   lines = 1
-  run = false
+  run = true
   buffer = 1_000
 
 [[inputs]]
@@ -21,14 +21,13 @@
 
 [[processors]]
   [processors.http]
-    host = "https://jsonplaceholder.typicode.com/posts"
-    method = "POST"
-#    path_label = "uri"
+    host = "http://localhost:9200"
+    fallbacks = [ "https://jsonplaceholder.typicode.com/posts" ]
+    method = "GET"
     retry_attempts = 3
     retry_after = "1s"
     tls_enable = true
     response_body_to = "typicode.response"
-    request_body_from = "payload"
     [processors.http.serializer]
       type = "json"
       data_only = false

--- a/plugins/filters/glob/README.md
+++ b/plugins/filters/glob/README.md
@@ -17,14 +17,14 @@ Glob syntax is similar to [standard wildcards](https://tldp.org/LDP/GNU-Linux-To
     # list of patterns, one of which an event routing key must match
     routing_key = [ "http*" ]
 
-    # "labels" is a "label name -> patterns list" map
+    # "labels" is a "label name <- patterns list" map
     [processors.through.filters.glob.labels]
       # list of patterns, one of which an event label must match
       # if label does not exists or not matched any pattern
       # event will be rejected
       sender = [ "*:8765" ]
 
-    # "fields" is a "field path -> patterns list" map
+    # "fields" is a "field path <- patterns list" map
     [processors.through.filters.glob.fields]
       # list of patterns, one of which an event field must match
       # if field does not exists, not a string or not matched any pattern

--- a/plugins/inputs/beats/README.md
+++ b/plugins/inputs/beats/README.md
@@ -47,7 +47,7 @@ Plugin produces events with `beats.{{ [@metadata][beat] }}` routing key, e.g. `b
     tls_min_version = "TLS12"
     tls_max_version = "TLS13"
 
-    # a "label name -> metadata key" map
+    # a "label name <- metadata key" map
     # if metadata key exists, it will be saved as configured label
     [inputs.beats.labelheaders]
       beat_version = "version"

--- a/plugins/inputs/grpc/README.md
+++ b/plugins/inputs/grpc/README.md
@@ -60,7 +60,7 @@ Plugin behavoiur depends on the procedure being called:
       inactive_transport_ping = "2h"
       inactive_transport_age = "20s"
 
-    # a "label name -> metadata" map
+    # a "label name <- metadata" map
     # if request metadata exists, it will be saved as configured label
     # used in SendOne and SendBulk procedures only
     [inputs.grpc.labelmetadata]

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -39,7 +39,7 @@ This plugin produce events with routing key as request path (or matched pattern 
 
     # optional basic auth credentials
     # if both set, requests with wrong credentials will be rejected with `401 Unauthorized`
-    basic_isername = "user"
+    basic_username = "user"
     basic_password = "pass"
 
     # allowed incoming requests methods, POST, PUT, GET
@@ -71,7 +71,7 @@ This plugin produce events with routing key as request path (or matched pattern 
     tls_min_version = "TLS12"
     tls_max_version = "TLS13"
 
-    # a "label name -> header" map
+    # a "label name <- header" map
     # if request header exists, it will be saved as configured label
     [inputs.http.labelheaders]
       length = "Content-Length"

--- a/plugins/inputs/httpl/README.md
+++ b/plugins/inputs/httpl/README.md
@@ -30,7 +30,7 @@ This plugin produce events with routing key as request path, `server` label with
 
     # optional basic auth credentials
     # if both set, requests with wrong credentials will be rejected with `401 Unauthorized`
-    basic_isername = "user"
+    basic_username = "user"
     basic_password = "pass"
 
     # if true, server waits for events to be delivered
@@ -55,7 +55,7 @@ This plugin produce events with routing key as request path, `server` label with
     tls_min_version = "TLS12"
     tls_max_version = "TLS13"
 
-    # a "label name -> header" map
+    # a "label name <- header" map
     # if request header exists, it will be saved as configured label
     [inputs.httpl.labelheaders]
       length = "Content-Length"

--- a/plugins/inputs/kafka/README.md
+++ b/plugins/inputs/kafka/README.md
@@ -105,7 +105,7 @@ If commit queue is full, fetching is suspended until at least one message is com
       username = ""
       password = ""
 
-    # a "label name -> header" map
+    # a "label name <- header" map
     # if message header exists, it will be saved as configured label
     [inputs.kafka.labelheaders]
       length = "Content-Length"

--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -131,7 +131,7 @@ If ACK queue is full, consuming is suspended until at least one message is ACKed
         # optional binding arguments
         declare_args = { "x-dead-letter-exchange" = "dlq" }
 
-    # a "label name -> header" map
+    # a "label name <- header" map
     # if message header exists, it will be saved as configured label
     [inputs.rabbitmq.labelheaders]
       extra-type = "msg-extra-type"

--- a/plugins/inputs/sql/README.md
+++ b/plugins/inputs/sql/README.md
@@ -81,7 +81,7 @@ Drivers use plugin TLS configuration.
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # a "label name -> column name" map
+    # a "label name <- column name" map
     # if column exists and can be mapped to string type, it will be saved as configured label
     [inputs.sql.labelcolumns]
       event_type = "type"

--- a/plugins/outputs/grpc/README.md
+++ b/plugins/outputs/grpc/README.md
@@ -76,7 +76,7 @@ Plugin can be configured for using one of three RPCs:
       # broken connections or unreachable servers
       wait_for_ready = false
 
-    # a "metadata -> label" map
+    # a "metadata <- label" map
     # if event label exists, it will be added as a call metadata
     # used in "one" mode only
     [outputs.grpc.metadatalabels]

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -70,13 +70,13 @@ Plugin creates one requester per each unique event routing key, with personal ba
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # a "header -> label" map
+    # a "header <- label" map
     # if event label exists, it will be added as a request header
     # ONLY FIRST EVENT IN BATCH USED
     [outputs.http.headerlabels]
       custom_header = "my_label_name"
 
-    # a "param -> field" map
+    # a "param <- field" map
     # if event field exists, it will be added as a request urlparam
     # target field must not be a map, but slices allowed, if slice not contains maps
     # ONLY FIRST EVENT IN BATCH USED

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -115,7 +115,7 @@ Each event will be serialized into a individual message, `batch_*` settings cont
       username = ""
       password = ""
 
-    # a "header -> label" map
+    # a "header <- label" map
     # if event label exists, it will be added as a message header
     [outputs.kafka.headerlabels]
       custom_header = "my_label_name"

--- a/plugins/outputs/log/log.go
+++ b/plugins/outputs/log/log.go
@@ -25,10 +25,10 @@ func (o *Log) Init() error {
 		o.logFunc = o.Log.Debug
 	case "info":
 		o.logFunc = o.Log.Info
-	case "warn":
-		o.logFunc = o.Log.Warn
+	case "error":
+		o.logFunc = o.Log.Error
 	default:
-		return fmt.Errorf("forbidden logging level: %v; expected one of: debug, info, warn", o.Level)
+		return fmt.Errorf("forbidden logging level: %v; expected one of: debug, info, warn, error", o.Level)
 	}
 
 	return nil

--- a/plugins/outputs/promremote/README.md
+++ b/plugins/outputs/promremote/README.md
@@ -97,7 +97,7 @@ traffic_now_avg{::line="3", region="US/California"} 11.9 1692991768912
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # a "header -> label" map
+    # a "header <- label" map
     # if event label exists, it will be added as a request header
     # ONLY FIRST EVENT IN BATCH USED
     [outputs.promremote.headerlabels]

--- a/plugins/outputs/rabbitmq/README.md
+++ b/plugins/outputs/rabbitmq/README.md
@@ -84,7 +84,7 @@ Each event will be serialized into a individual message, `batch_*` settings cont
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # a "header -> label" map
+    # a "header <- label" map
     # if event label exists, it will be added as a message header
     [outputs.rabbitmq.headerlabels]
       custom_header = "my_label_name"

--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -76,7 +76,7 @@ Drivers use plugin TLS configuration.
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # "push query placeholders -> event fields" mapping
+    # "push query placeholders <- event fields" mapping
     [outputs.sql.columns]
       expedition_type = "type"
       expedition_region = "region"

--- a/plugins/processors/clone/README.md
+++ b/plugins/processors/clone/README.md
@@ -15,7 +15,7 @@ The `clone` processor creates clone of each event with new routing key and extra
     # clones count
     count = 1
 
-    # "labels" is a "label name -> label value" map
+    # "labels" is a "label name <- label value" map
     # if label does not exists, it will be added
     # if label already exists, it will be overwritten
     [processors.clone.labels]

--- a/plugins/processors/deduplicate/client.go
+++ b/plugins/processors/deduplicate/client.go
@@ -1,9 +1,0 @@
-package deduplicate
-
-import (
-	"github.com/redis/go-redis/v9"
-
-	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
-)
-
-var clientStorage = sharedstorage.New[redis.UniversalClient]()

--- a/plugins/processors/deduplicate/deduplicate.go
+++ b/plugins/processors/deduplicate/deduplicate.go
@@ -13,8 +13,11 @@ import (
 	"github.com/gekatateam/neptunus/plugins"
 	"github.com/gekatateam/neptunus/plugins/common/elog"
 	"github.com/gekatateam/neptunus/plugins/common/retryer"
+	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
 	"github.com/gekatateam/neptunus/plugins/common/tls"
 )
+
+var clientStorage = sharedstorage.New[redis.UniversalClient]()
 
 type Deduplicate struct {
 	*core.BaseProcessor `mapstructure:"-"`

--- a/plugins/processors/defaults/README.md
+++ b/plugins/processors/defaults/README.md
@@ -6,10 +6,10 @@ The `defaults` processor adds configured labels and fields to an event if they n
 
 ```toml
 [[processors]]
-  # "labels" is a "label name -> label value" map
+  # "labels" is a "label name <- label value" map
   [processors.defaults.labels]
     dc = 'east-01'
-  # "fields" is a "field path -> field value" map
+  # "fields" is a "field path <- field value" map
   [processors.defaults.fields]
     tested = true
     # use dots as a path separator to access nested keys

--- a/plugins/processors/delete/README.md
+++ b/plugins/processors/delete/README.md
@@ -7,9 +7,9 @@ The `delete` processor deletes events labels and fields.
 [[processors]]
   [processors.delete]
 
-    // list of labels to delete
+    # list of labels to delete
     labels = [ "sender", "exchange" ]
 
-    // list of fields to delete
+    # list of fields to delete
     fields = [ "log.source", "fqdn" ]
 ```

--- a/plugins/processors/http/README.md
+++ b/plugins/processors/http/README.md
@@ -13,6 +13,10 @@ Please note, that in multiline configuration HTTP client is shared between proce
     # target host, required
     host = "http://localhost:9100"
 
+    # list of fallback hosts
+    # if all `retry_attempts` to perform request to `host` failed, fallbacks will be used
+    fallbacks = [ "http://fallback.local:9100", "http://anotherfallback.local:9100" ]
+
     # request method, required
     method = "POST"
 
@@ -65,12 +69,17 @@ Please note, that in multiline configuration HTTP client is shared between proce
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # a "header -> label" map
+    # a "header <- label" map
     # if event label exists, it will be added as a request header
     [processors.http.headerlabels]
       custom_header = "my_label_name"
 
-    # a "param -> field" map
+    # a "label <- header" map
+    # if response header exists, it will be saved as configured label
+    [processors.http.labelheaders]
+      my_label_name = "x-custom-header"
+
+    # a "param <- field" map
     # if event field exists, it will be added as a request urlparam
     # target field must not be a map, but slices allowed, if slice not contains maps
     [processors.http.paramfields]

--- a/plugins/processors/http/client.go
+++ b/plugins/processors/http/client.go
@@ -1,9 +1,0 @@
-package http
-
-import (
-	"net/http"
-
-	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
-)
-
-var clientStorage = sharedstorage.New[*http.Client]()

--- a/plugins/processors/log/log.go
+++ b/plugins/processors/log/log.go
@@ -27,8 +27,10 @@ func (p *Log) Init() error {
 		p.logFunc = p.Log.Info
 	case "warn":
 		p.logFunc = p.Log.Warn
+	case "error":
+		p.logFunc = p.Log.Error
 	default:
-		return fmt.Errorf("forbidden logging level: %v; expected one of: debug, info, warn", p.Level)
+		return fmt.Errorf("forbidden logging level: %v; expected one of: debug, info, warn, error", p.Level)
 	}
 
 	return nil

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -9,11 +9,11 @@ Regex processor only works with string fields, any other types will be ignored. 
 ## Configuration
 ```toml
 [[processors]]
-  # "labels" is a "label name -> regexp" map
+  # "labels" is a "label name <- regexp" map
   [processors.regex.labels]
     sender = '^(?P<host>.+):(?P<port>[0-9]+)$'
 
-  # "fields" is a "field path -> regexp" map
+  # "fields" is a "field path <- regexp" map
   [processors.regex.fields]
     message = '(?P<url>http(s)://\S+)'
     # use dots as a path separator to access nested keys

--- a/plugins/processors/rk/README.md
+++ b/plugins/processors/rk/README.md
@@ -5,7 +5,7 @@ The `rk` processor plugin replaces an event routing key with a new one, dependin
 ## Configuration
 ```toml
 [[processors]]
-  # "mapping" is a "new key -> old keys" map
+  # "mapping" is a "new key <- old keys" map
   # event routing key will be replaced with a new value 
   # if current key matches one in a list
   [processors.rk.mapping]

--- a/plugins/processors/sql/README.md
+++ b/plugins/processors/sql/README.md
@@ -68,13 +68,13 @@ Drivers use plugin TLS configuration.
     # use TLS but skip chain & host verification
     tls_insecure_skip_verify = false
 
-    # "query placeholders -> event fields" mapping
+    # "query placeholders <- event fields" mapping
     [processors.sql.columns]
       expedition_type = "type"
       expedition_region = "region"
       expedition_owner = "owner"
 
-    # "event fields -> query result columns" mapping
+    # "event fields <- query result columns" mapping
     # please note that each field type is always a slice
     [processors.sql.fields]
       uid = "expedition_uid"

--- a/plugins/processors/sql/client.go
+++ b/plugins/processors/sql/client.go
@@ -1,9 +1,0 @@
-package sql
-
-import (
-	"github.com/jmoiron/sqlx"
-
-	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
-)
-
-var clientStorage = sharedstorage.New[*sqlx.DB]()

--- a/plugins/processors/sql/sql.go
+++ b/plugins/processors/sql/sql.go
@@ -15,11 +15,14 @@ import (
 	"github.com/gekatateam/neptunus/plugins/common/elog"
 	dbstats "github.com/gekatateam/neptunus/plugins/common/metrics"
 	"github.com/gekatateam/neptunus/plugins/common/retryer"
+	"github.com/gekatateam/neptunus/plugins/common/sharedstorage"
 	csql "github.com/gekatateam/neptunus/plugins/common/sql"
 	"github.com/gekatateam/neptunus/plugins/common/tls"
 )
 
 const tablePlaceholder = ":table_name"
+
+var clientStorage = sharedstorage.New[*sqlx.DB]()
 
 type Sql struct {
 	*core.BaseProcessor `mapstructure:"-"`

--- a/plugins/processors/stats/README.md
+++ b/plugins/processors/stats/README.md
@@ -66,7 +66,7 @@ This is the format of stats event:
     # if true, consumed events will be dropped after stats collection
     drop_origin = false
 
-    # "fields" is a "field path -> stats" map
+    # "fields" is a "field path <- stats" map
     # plugin expects: "count", "sum", "gauge", "avg", "min", "max", "histogram"
     # any other value or an empty list will cause an error
     [processors.stats.fields]

--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -16,11 +16,11 @@ If template execution or field setting fails, event is marked as failed, but oth
     # id template
     id = '{{ .GetLabel "message_id" }}'
 
-    # "label name -> template" map
+    # "label name <- template" map
     [processors.template.labels]
       host = '{{ .GetField "client.host" }}:{{ .GetField "client.port" }}'
 
-    # "field path -> template" map
+    # "field path <- template" map
     [processors.template.fields]
       "metadata.full_address" = '{{ .GetField "address.street" }}, {{ .GetField "address.building" }}'
 ```


### PR DESCRIPTION
Also:
 - `log` processor and output - `error` log level support added
 - `http` processor now can save response headers as event labels, if configured