### PR TITLE
use bytes Buffers from shared pool

### DIFF
--- a/.pipelines/test.pipeline.httpproc.toml
+++ b/.pipelines/test.pipeline.httpproc.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.httpproc"
   lines = 1
-  run = false
+  run = true
   buffer = 1_000
   log_level = "debug"
 

--- a/.pipelines/test.pipeline.protobuf.toml
+++ b/.pipelines/test.pipeline.protobuf.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.protobuf"
   lines = 1
-  run = true
+  run = false
   buffer = 1_000
 
 [[inputs]]

--- a/plugins/common/baiscpools/bytesbuffer.go
+++ b/plugins/common/baiscpools/bytesbuffer.go
@@ -1,0 +1,12 @@
+package baiscpools
+
+import (
+	"bytes"
+	"sync"
+)
+
+var BytesBuffer = &sync.Pool{
+	New: func() any {
+		return bytes.NewBuffer(make([]byte, 0, 4096))
+	},
+}

--- a/plugins/common/esopensearch/bulk_body.go
+++ b/plugins/common/esopensearch/bulk_body.go
@@ -30,7 +30,6 @@ func (b *BulkBody) CreateOp(doc []byte, params BulkOp) error {
 		return fmt.Errorf("bulk.CreateOp: %w", err)
 	}
 
-	//b.WriteByte('\n')
 	b.Write(doc)
 	b.WriteByte('\n')
 	return nil
@@ -41,7 +40,6 @@ func (b *BulkBody) IndexOp(doc []byte, params BulkOp) error {
 		return fmt.Errorf("bulk.IndexOp: %w", err)
 	}
 
-	//b.WriteByte('\n')
 	b.Write(doc)
 	b.WriteByte('\n')
 	return nil

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gekatateam/neptunus/metrics"
 	"github.com/gekatateam/neptunus/pkg/slices"
 	"github.com/gekatateam/neptunus/plugins"
+	"github.com/gekatateam/neptunus/plugins/common/baiscpools"
 	"github.com/gekatateam/neptunus/plugins/common/elog"
 	basic "github.com/gekatateam/neptunus/plugins/common/http"
 	"github.com/gekatateam/neptunus/plugins/common/ider"
@@ -176,7 +177,10 @@ func (i *Http) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"path", r.URL.Path,
 	)
 
-	buf := bytes.NewBuffer(make([]byte, 0, defaultBufferSize))
+	buf := baiscpools.BytesBuffer.Get().(*bytes.Buffer)
+	defer baiscpools.BytesBuffer.Put(buf)
+	defer buf.Reset()
+
 	_, err := buf.ReadFrom(r.Body)
 	if err != nil {
 		i.Log.Error("body read error",
@@ -258,7 +262,7 @@ func (i *Http) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wg.Wait()
 
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write([]byte(fmt.Sprintf("accepted events: %v", len(e))))
+	_, err = fmt.Fprintf(w, "accepted events: %v", len(e))
 	if err != nil {
 		i.Log.Warn("all events accepted, but sending response to client failed",
 			"error", err,

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -26,8 +26,6 @@ import (
 	pkgtls "github.com/gekatateam/neptunus/plugins/common/tls"
 )
 
-const defaultBufferSize = 4096
-
 type Http struct {
 	*core.BaseInput `mapstructure:"-"`
 	EnableMetrics   bool              `mapstructure:"enable_metrics"`

--- a/plugins/outputs/opensearch/indexer.go
+++ b/plugins/outputs/opensearch/indexer.go
@@ -52,14 +52,20 @@ func (i *indexer) Push(e *core.Event) {
 func (i *indexer) Run() {
 	i.Log.Info(fmt.Sprintf("indexer for pipeline %v spawned", i.pipeline))
 
+	body := &esopensearch.BulkBody{
+		Buffer: bytes.NewBuffer(make([]byte, 0, defaultBufferSize)),
+	}
+
 	i.Batcher.Run(i.input, func(buf []*core.Event) {
+		defer body.Reset()
+
 		if len(buf) == 0 {
 			return
 		}
+
 		var (
 			now        time.Time              = time.Now()
 			sentEvents []measurableEvent      = make([]measurableEvent, 0, len(buf))
-			body       *esopensearch.BulkBody = &esopensearch.BulkBody{Buffer: bytes.NewBuffer(make([]byte, 0, defaultBufferSize))}
 			req        *opensearchapi.BulkReq = &opensearchapi.BulkReq{Params: opensearchapi.BulkParams{Pipeline: i.pipeline}}
 		)
 

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gekatateam/neptunus/core"
 	"github.com/gekatateam/neptunus/metrics"
 	"github.com/gekatateam/neptunus/plugins"
+	"github.com/gekatateam/neptunus/plugins/common/baiscpools"
 	"github.com/gekatateam/neptunus/plugins/common/elog"
 )
 
@@ -58,9 +59,11 @@ func (s *Json) Serialize(events ...*core.Event) ([]byte, error) {
 
 func (s *Json) serializeTryAll(events ...*core.Event) ([]byte, error) {
 	now := time.Now()
-	buf := bytes.NewBuffer(make([]byte, 0, 4096))
-	buf.WriteString(s.start)
+	buf := baiscpools.BytesBuffer.Get().(*bytes.Buffer)
+	defer baiscpools.BytesBuffer.Put(buf)
+	defer buf.Reset()
 
+	buf.WriteString(s.start)
 	for _, e := range events {
 		rawData, err := s.eventOrData(e)
 		if err != nil {
@@ -90,8 +93,9 @@ func (s *Json) serializeTryAll(events ...*core.Event) ([]byte, error) {
 
 func (s *Json) serializeFailFast(events ...*core.Event) ([]byte, error) {
 	now := time.Now()
-	buf := bytes.NewBuffer(make([]byte, 0, 4096))
-	buf.WriteString(s.start)
+	buf := baiscpools.BytesBuffer.Get().(*bytes.Buffer)
+	defer baiscpools.BytesBuffer.Put(buf)
+	defer buf.Reset()
 
 	var sErr error
 	last := len(events) - 1

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -97,6 +97,7 @@ func (s *Json) serializeFailFast(events ...*core.Event) ([]byte, error) {
 	defer baiscpools.BytesBuffer.Put(buf)
 	defer buf.Reset()
 
+	buf.WriteString(s.start)
 	var sErr error
 	last := len(events) - 1
 	for i, e := range events {

--- a/plugins/serializers/protobuf/protobuf.go
+++ b/plugins/serializers/protobuf/protobuf.go
@@ -45,13 +45,13 @@ func (s *Protobuf) Close() error {
 
 func (s *Protobuf) Serialize(events ...*core.Event) ([]byte, error) {
 	now := time.Now()
+	err := errors.New("protobuf serializer accepts exactly one event per call")
 
 	if len(events) == 0 {
-		return nil, errors.New("protobuf serializer accepts exactly one event per call")
+		return nil, nil
 	}
 
 	if len(events) != 1 {
-		err := errors.New("protobuf serializer accepts only one event per call")
 		for _, e := range events {
 			s.Log.Error("event serialization failed",
 				"error", err,

--- a/plugins/serializers/template_text/template.go
+++ b/plugins/serializers/template_text/template.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gekatateam/neptunus/core"
 	"github.com/gekatateam/neptunus/metrics"
 	"github.com/gekatateam/neptunus/plugins"
+	"github.com/gekatateam/neptunus/plugins/common/baiscpools"
 	"github.com/gekatateam/neptunus/plugins/common/elog"
 	cte "github.com/gekatateam/neptunus/plugins/common/template"
 )
@@ -58,14 +59,16 @@ func (t *TemplateText) Init() error {
 
 func (t *TemplateText) parseBatch(events ...*core.Event) ([]byte, error) {
 	now := time.Now()
-	buff := bytes.NewBuffer(make([]byte, 0, 3072))
+	buf := baiscpools.BytesBuffer.Get().(*bytes.Buffer)
+	defer baiscpools.BytesBuffer.Put(buf)
+	defer buf.Reset()
 
 	te := make([]cte.TEvent, 0, len(events))
 	for _, e := range events {
 		te = append(te, cte.New(e))
 	}
 
-	err := t.template.Execute(buff, te)
+	err := t.template.Execute(buf, te)
 	for _, e := range events {
 		if err != nil {
 			t.Log.Error("template serialization failed",
@@ -81,7 +84,7 @@ func (t *TemplateText) parseBatch(events ...*core.Event) ([]byte, error) {
 		}
 		now = time.Now()
 	}
-	return buff.Bytes(), err
+	return buf.Bytes(), err
 }
 
 func init() {


### PR DESCRIPTION
Also:
 - `elasticsearch` and `opensearch` indexers now reuse the same body buffer after every flush