### PR TITLE
`stats` processor - default metric TTL

### DIFF
--- a/core/base.go
+++ b/core/base.go
@@ -168,7 +168,7 @@ func (sc *SerializerComperssor) Close() error {
 	if sc.C != nil {
 		err = sc.C.Close()
 	}
-	err = sc.S.Close()
+	err = errors.Join(err, sc.S.Close())
 	return err
 }
 
@@ -198,7 +198,7 @@ func (pd *ParserDecompressor) Close() error {
 	if pd.D != nil {
 		err = pd.D.Close()
 	}
-	err = pd.P.Close()
+	err = errors.Join(err, pd.P.Close())
 	return err
 }
 

--- a/core/event.go
+++ b/core/event.go
@@ -29,7 +29,7 @@ func NewEvent(routingKey string) *Event {
 		Timestamp:  time.Now(),
 		RoutingKey: routingKey,
 		Tags:       make([]string, 0, 5),
-		Labels:     make(map[string]string),
+		Labels:     make(map[string]string, 5),
 		Data:       nil,
 	}
 }
@@ -41,7 +41,7 @@ func NewEventWithData(routingKey string, data any) *Event {
 		Timestamp:  time.Now(),
 		RoutingKey: routingKey,
 		Tags:       make([]string, 0, 5),
-		Labels:     make(map[string]string),
+		Labels:     make(map[string]string, 5),
 		Data:       data,
 	}
 }

--- a/plugins/processors/stats/README.md
+++ b/plugins/processors/stats/README.md
@@ -52,8 +52,8 @@ This is the format of stats event:
 
     # metrics TTL
     # any metric that has not been observed longer than TTL will be deleted
-    # zero means to TTL
-    metric_ttl = "0s"
+    # zero means no limit
+    metric_ttl = "30m"
 
     # routing key with which events will be created
     routing_key = "neptunus.generated.metric"

--- a/plugins/processors/stats/cache.go
+++ b/plugins/processors/stats/cache.go
@@ -29,6 +29,7 @@ func newIndividualCache() individualCache {
 
 func (c individualCache) observe(m *metric, b map[float64]float64, v float64) {
 	hash := m.hash()
+	c.d[hash] = time.Now()
 
 	if metric, ok := c.c[hash]; ok {
 		m = metric
@@ -39,7 +40,6 @@ func (c individualCache) observe(m *metric, b map[float64]float64, v float64) {
 		c.c[hash] = m
 	}
 
-	c.d[hash] = time.Now()
 	m.observe(v)
 }
 

--- a/plugins/processors/stats/stats.go
+++ b/plugins/processors/stats/stats.go
@@ -108,7 +108,7 @@ func (p *Stats) Run() {
 	flushTicker := time.NewTicker(p.Period)
 	defer flushTicker.Stop()
 
-	clearTicker := time.NewTicker(time.Minute + 55*time.Millisecond)
+	clearTicker := time.NewTicker(time.Minute + 555*time.Millisecond)
 	defer clearTicker.Stop()
 	if p.MetricTTL == 0 {
 		clearTicker.Stop()
@@ -276,6 +276,7 @@ func init() {
 	plugins.AddProcessor("stats", func() core.Processor {
 		return &Stats{
 			Period:     time.Minute,
+			MetricTTL:  30 * time.Minute,
 			RoutingKey: "neptunus.generated.metric",
 			Mode:       "shared",
 			Buckets:    []float64{0.1, 0.3, 0.5, 0.7, 1.0, 2.0, 5.0, 10.0},


### PR DESCRIPTION
Also:
 - core `NewEvent*` - preallocate labels map with some length to prevent unnecessary allocations in most cases