### PR TITLE
mixer - release output channel before break run loop

### DIFF
--- a/.pipelines/test.pipeline.http.toml
+++ b/.pipelines/test.pipeline.http.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.http"
   lines = 1
-  run = true
+  run = false
   buffer = 1_000
 
 [[inputs]]

--- a/.pipelines/test.pipeline.mixer.toml
+++ b/.pipelines/test.pipeline.mixer.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.mixer"
   lines = 8
-  run = false
+  run = true
   buffer = 5
   log_level = "info"
 
@@ -17,6 +17,10 @@
       name = "partition.create"
       schedule = "@every 1s"
       force = true
+
+[[processors]]
+  [processors.through]
+    sleep = "5s"
 
 [[processors]]
   [processors.starlark]

--- a/plugins/core/mixer/mixer.go
+++ b/plugins/core/mixer/mixer.go
@@ -47,12 +47,11 @@ func (p *Mixer) Close() error {
 	stored.mu.Lock()
 	defer stored.mu.Unlock()
 
-	delete(stored.ch, p.line)
-	p.Log.Info(fmt.Sprintf("event output chan deleted on line %v; channels total: %v", p.line, len(stored.ch)))
-
 	if len(stored.ch) == 0 {
 		outs.Delete(p.id)
+		p.Log.Info("no output channels left, chans set deleted")
 	}
+
 	return nil
 }
 
@@ -107,4 +106,16 @@ func (p *Mixer) Run() {
 
 		p.Observe(metrics.EventAccepted, time.Since(now))
 	}
+
+	curr, ok := outs.Load(p.id)
+	if !ok {
+		return
+	}
+
+	stored := curr.(outputChans)
+	stored.mu.Lock()
+	defer stored.mu.Unlock()
+
+	delete(stored.ch, p.line)
+	p.Log.Info(fmt.Sprintf("event output chan deleted on line %v; channels total: %v", p.line, len(stored.ch)))
 }


### PR DESCRIPTION
This bug was caused by a change in how plugins are closed. Previously, the `Close() error` method was called immediately after exiting the run loop and before closing the output channel. After version 1.13, the method is called after pipeline has completely stopped.