### PR TITLE
self keykeeper - cast vars to map first

### DIFF
--- a/.pipelines/test.pipeline.mixer.toml
+++ b/.pipelines/test.pipeline.mixer.toml
@@ -5,6 +5,9 @@
   buffer = 5
   log_level = "info"
 
+[vars]
+  statsmode = "shared"
+
 [[keykeepers]]
   [keykeepers.self]
     alias = "self"
@@ -56,7 +59,7 @@ def process(event):
 
 [[processors]]
   [processors.stats]
-    mode = "shared"
+    mode = "@{self:vars.statsmode}"
     period = "2s"
     [processors.stats.fields]
       c = [ "gauge", "count", "sum" ]

--- a/plugins/core/self/self.go
+++ b/plugins/core/self/self.go
@@ -17,7 +17,7 @@ func (k *Self) Init() error {
 
 func (k *Self) SetConfig(config *config.Pipeline) {
 	k.cfg = make(map[string]any)
-	k.cfg["vars"] = config.Vars
+	k.cfg["vars"] = map[string]any(config.Vars)
 	k.cfg["settings"] = map[string]any{
 		"id":          config.Settings.Id,
 		"lines":       config.Settings.Lines,


### PR DESCRIPTION
This bug was caused by a change in configuration parsing - previously, pipeline variables were a `map[string]any`, but after version 1.13, it became a different data type.