### PR TITLE
sql input - allow to configure initial values for `onPoll` query

### DIFF
--- a/.pipelines/test.pipeline.mixer.toml
+++ b/.pipelines/test.pipeline.mixer.toml
@@ -1,7 +1,7 @@
 [settings]
   id = "test.pipeline.mixer"
   lines = 8
-  run = true
+  run = false
   buffer = 5
   log_level = "info"
 

--- a/.pipelines/test.pipeline.sql.toml
+++ b/.pipelines/test.pipeline.sql.toml
@@ -1,8 +1,9 @@
 [settings]
   id = "test.pipeline.sql"
   lines = 1
-  run = false
+  run = true
   buffer = 1_000
+  log_level = "debug"
 
 [[inputs]]
   [inputs.sql]
@@ -15,6 +16,8 @@
     [inputs.sql.keep_values]
       last = [ "insert_timestamp" ]
       all = [ "id" ]
+    [inputs.sql.initial_values]
+      insert_timestamp = "2026-03-22 11:18:15.870331+00"
     [inputs.sql.on_init]
       query = '''
 SELECT INSERT_TIMESTAMP FROM POLLING_TABLE

--- a/plugins/inputs/sql/README.md
+++ b/plugins/inputs/sql/README.md
@@ -101,6 +101,13 @@ Drivers use plugin TLS configuration.
       last = [ "insert_timestamp" ]
       all = [ "id" ]
 
+    # initial values for onPoll query
+    # in case, when onInit query returns zero rows
+    # anyway, if onInit query successfully selected some values
+    # "initial_values" with same keys will be overrided
+    [inputs.sql.initial_values]
+      insert_timestamp = "2026-03-22 11:18:15.870331+00"
+
     # initializing query, executed once on plugin startup
     # if both, "file" and "query" are set, file is prioritized
     [inputs.sql.on_init]

--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -48,11 +49,12 @@ type Sql struct {
 	IsolationLevel string `mapstructure:"isolation_level"`
 	ReadOnly       bool   `mapstructure:"read_only"`
 
-	OnInit       csql.QueryInfo    `mapstructure:"on_init"`
-	OnPoll       csql.QueryInfo    `mapstructure:"on_poll"`
-	OnDone       csql.QueryInfo    `mapstructure:"on_done"`
-	KeepValues   KeepValues        `mapstructure:"keep_values"`
-	LabelColumns map[string]string `mapstructure:"labelcolumns"`
+	OnInit        csql.QueryInfo    `mapstructure:"on_init"`
+	OnPoll        csql.QueryInfo    `mapstructure:"on_poll"`
+	OnDone        csql.QueryInfo    `mapstructure:"on_done"`
+	KeepValues    KeepValues        `mapstructure:"keep_values"`
+	InitialValues map[string]any    `mapstructure:"initial_values"`
+	LabelColumns  map[string]string `mapstructure:"labelcolumns"`
 
 	keepIndex  map[string]int
 	keepValues map[string]any
@@ -79,7 +81,7 @@ func (i *Sql) Init() error {
 		}
 	}
 
-	i.keepValues = make(map[string]any)
+	i.keepValues = i.InitialValues
 	i.keepIndex = make(map[string]int)
 	for _, v := range i.KeepValues.First {
 		if _, ok := i.keepIndex[v]; ok {
@@ -200,7 +202,10 @@ func (i *Sql) init() error {
 		first = false
 	}
 
-	i.keepValues = keepValues
+	// add fetched values to keepValues
+	// override existing ones if duplicated, because fetched are more up to date
+	maps.Copy(i.keepValues, keepValues)
+
 	return nil
 }
 
@@ -363,6 +368,7 @@ func init() {
 				QueryTimeout:     30 * time.Second,
 				TLSClientConfig:  &tls.TLSClientConfig{},
 			},
+			InitialValues:   map[string]any{},
 			Transactional:   false,
 			IsolationLevel:  "Default",
 			Interval:        0,


### PR DESCRIPTION
In case, if `onInit` query returns nothing. For example, if you trying to read data from empty (at startup) polling table (see doc for more details)